### PR TITLE
test:java-clientのバージョンを上げる、それに伴うコードのリファクタリング

### DIFF
--- a/appium/Java/pom.xml
+++ b/appium/Java/pom.xml
@@ -11,17 +11,23 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<junit.version>4.13.1</junit.version>
-		<junit.jupiter.version>5.2.0</junit.jupiter.version>
-		<junit.vintage.version>5.2.0</junit.vintage.version>
-		<junit.platform.version>1.2.0</junit.platform.version>
+		<junit.version>4.13.2</junit.version>
+		<junit.jupiter.version>5.9.0</junit.jupiter.version>
+		<junit.vintage.version>5.9.0</junit.vintage.version>
+		<junit.platform.version>1.9.0</junit.platform.version>
 	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>io.appium</groupId>
 			<artifactId>java-client</artifactId>
-			<version>6.0.0</version>
+			<version>8.2.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.seleniumhq.selenium</groupId>
+					<artifactId>selenium-java</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -61,8 +67,31 @@
 		<dependency>
 			<groupId>org.apiguardian</groupId>
 			<artifactId>apiguardian-api</artifactId>
-			<version>1.0.0</version>
+			<version>1.1.2</version>
 			<scope>test</scope>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>2.0.3</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>2.0.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-remote-driver</artifactId>
+			<version>4.5.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.seleniumhq.selenium</groupId>
+			<artifactId>selenium-api</artifactId>
+			<version>4.5.0</version>
 		</dependency>
 	</dependencies>
 
@@ -77,8 +106,9 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.19.1</version>
+				<version>2.22.2</version>
 				<configuration>
 					<includes>
 						<include>**/Test*.java</include>
@@ -91,7 +121,7 @@
 					<dependency>
 						<groupId>org.junit.platform</groupId>
 						<artifactId>junit-platform-surefire-provider</artifactId>
-						<version>${junit.platform.version}</version>
+						<version>1.2.0</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/appium/Java/src/test/java/com/remotetestkit/appium/AndroidApplicationTest.java
+++ b/appium/Java/src/test/java/com/remotetestkit/appium/AndroidApplicationTest.java
@@ -2,27 +2,29 @@
 
 package com.remotetestkit.appium;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.net.URL;
 import java.util.List;
 
+import io.appium.java_client.android.nativekey.AndroidKey;
+import io.appium.java_client.android.nativekey.KeyEvent;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.OutputType;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.AndroidElement;
 import io.appium.java_client.remote.AndroidMobileCapabilityType;
 import io.appium.java_client.remote.MobileCapabilityType;
 
 public class AndroidApplicationTest {
 
-	private static AndroidDriver<AndroidElement> driver;
+	private static AndroidDriver driver;
 
 	@BeforeAll
 	static void initAll() throws Exception {
@@ -36,7 +38,7 @@ public class AndroidApplicationTest {
 		capabilities.setCapability("unicodeKeyboard", true);
 		capabilities.setCapability("resetKeyboard", true);
 		capabilities.setCapability(MobileCapabilityType.NEW_COMMAND_TIMEOUT, Integer.toString(180));
-		capabilities.setCapability(MobileCapabilityType.APPIUM_VERSION, "1.15.1");
+		capabilities.setCapability("appiumVersion", "1.22.3");
 		// set application from RemoteTestKit storage
 		// capabilities.setCapability(MobileCapabilityType.APP, "RTKdemo.apk");
 		// set application from HTTP Url
@@ -44,7 +46,7 @@ public class AndroidApplicationTest {
 		capabilities.setCapability(AndroidMobileCapabilityType.APP_PACKAGE, "com.example.remotetestkit.demo");
 		capabilities.setCapability(AndroidMobileCapabilityType.APP_ACTIVITY, "MainActivity");
 
-		driver = new AndroidDriver<>(new URL("https://gwjp.appkitbox.com/wd/hub"), capabilities);
+		driver = new AndroidDriver(new URL("https://gwjp.appkitbox.com/wd/hub"), capabilities);
 
 	}
 
@@ -56,40 +58,40 @@ public class AndroidApplicationTest {
 	@Test
 	void loginTest() throws Exception {
 		System.out.println("snapshotUrl: " + driver.getCapabilities().getCapability("snapshotUrl"));
-		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_01.png"));
+		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_A01.png"));
 
 		// get text fields and set text in it
-		List<AndroidElement> textfields = driver.findElementsByClassName("android.widget.EditText");
-		textfields.get(0).sendKeys("RTK");
-		textfields.get(1).sendKeys("Remote TestKing");
-		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_02.png"));
+		List<WebElement> textFields = driver.findElements(By.className("android.widget.EditText"));
+		textFields.get(0).sendKeys("RTK");
+		textFields.get(1).sendKeys("Remote TestKing");
+		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_A02.png"));
 
 		// click Save button
-		AndroidElement element = driver.findElementById("com.example.remotetestkit.demo:id/Save");
+		WebElement element = driver.findElement(By.id("com.example.remotetestkit.demo:id/Save"));
 		element.click();
 
 		// set text from Login display
-		AndroidElement result = driver.findElementById("com.example.remotetestkit.demo:id/title4");
-		System.out.println("Login Result : " + result.getText().toString());
-		assertEquals("Password Error", result.getText().toString());
-		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_03.png"));
+		WebElement result = driver.findElement(By.id("com.example.remotetestkit.demo:id/title4"));
+		System.out.println("Login Result : " + result.getText());
+		Assertions.assertEquals("Password Error", result.getText());
+		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_A03.png"));
 
 		// press return key
-		driver.pressKeyCode(4);
+		driver.pressKey(new KeyEvent(AndroidKey.BACK));
 
 		// delete and set text to text fields
-		textfields.get(1).clear();
-		textfields.get(1).sendKeys("Remote TestKit");
-		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_04.png"));
+		textFields.get(1).clear();
+		textFields.get(1).sendKeys("Remote TestKit");
+		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_A04.png"));
 
 		// click Save button
 		element.click();
 
 		// get text from Login display
-		result = driver.findElementById("com.example.remotetestkit.demo:id/title2");
-		System.out.println("Login Result : " + result.getText().toString());
-		assertEquals("Logged in", result.getText().toString());
-		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_05.png"));
+		result = driver.findElement(By.id("com.example.remotetestkit.demo:id/title2"));
+		System.out.println("Login Result : " + result.getText());
+		Assertions.assertEquals("Logged in", result.getText());
+		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_A05.png"));
 
 		Thread.sleep(5000);
 	}

--- a/appium/Java/src/test/java/com/remotetestkit/appium/AndroidChromeTest.java
+++ b/appium/Java/src/test/java/com/remotetestkit/appium/AndroidChromeTest.java
@@ -1,27 +1,29 @@
 package com.remotetestkit.appium;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.net.URL;
 
+import io.appium.java_client.android.nativekey.AndroidKey;
+import io.appium.java_client.android.nativekey.KeyEvent;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import io.appium.java_client.android.AndroidDriver;
-import io.appium.java_client.android.AndroidElement;
-import io.appium.java_client.android.AndroidKeyCode;
 import io.appium.java_client.remote.AndroidMobileCapabilityType;
 import io.appium.java_client.remote.MobileCapabilityType;
 
 import org.openqa.selenium.OutputType;
+import org.openqa.selenium.Keys;
 
 public class AndroidChromeTest {
 
-	private static AndroidDriver<AndroidElement> driver;
+	private static AndroidDriver driver;
 
 	@BeforeAll
 	static void initAll() throws Exception {
@@ -33,9 +35,9 @@ public class AndroidChromeTest {
 		capabilities.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
 		capabilities.setCapability(MobileCapabilityType.DEVICE_NAME, "Nexus 5");
 		capabilities.setCapability(AndroidMobileCapabilityType.BROWSER_NAME, "Chrome");
-		capabilities.setCapability(MobileCapabilityType.APPIUM_VERSION, "1.15.1");
+		capabilities.setCapability("appiumVersion", "1.22.3");
 
-		driver = new AndroidDriver<>(new URL("https://gwjp.appkitbox.com/wd/hub"), capabilities);
+		driver = new AndroidDriver(new URL("https://gwjp.appkitbox.com/wd/hub"), capabilities);
 	}
 
 	@AfterAll
@@ -51,24 +53,24 @@ public class AndroidChromeTest {
 		String url = "https://www.google.com/";
 		System.out.println("Open URL: " + url);
 		driver.get(url);
-		AndroidElement element = driver.findElementByName("q");
+		WebElement element = driver.findElement(By.name("q"));
 		Thread.sleep(5000);
-		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_01.png"));
+		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_B01.png"));
 
 		// Input keys
 		String word = "Remote TestKit";
 		System.out.println("Input Keys: " + word);
 		element.sendKeys(word);
-		element.submit();
+		element.sendKeys(Keys.chord(Keys.ENTER));
 		Thread.sleep(5000);
-		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_02.png"));
+		FileUtils.copyFile(driver.getScreenshotAs(OutputType.FILE), new File("capture_B02.png"));
 
 		// Get value
-		String value = driver.findElementByName("q").getAttribute("value");
+		String value = driver.findElement(By.name("q")).getAttribute("value");
 		System.out.println("Text field value=" + value);
-		assertEquals(value, "Remote TestKit");
+		Assertions.assertEquals(value, "Remote TestKit");
 
-		driver.pressKeyCode(AndroidKeyCode.KEYCODE_APP_SWITCH);
-		driver.pressKeyCode(AndroidKeyCode.KEYCODE_HOME);
+		driver.pressKey(new KeyEvent(AndroidKey.APP_SWITCH));
+		driver.pressKey(new KeyEvent(AndroidKey.HOME));
 	}
 }


### PR DESCRIPTION
java-clientを8.2.0に最新化しました。（また他のモジュールも問題なさそうなので最新化しました）
それに伴い、コードもリファクタリングしました。
以下、モジュール関連での補足です。
・seleniumは4.5.1以上でスクリーンショットのエラーが出るため明示的に4.5.0を指定しています
・org.slf4j関連はテスト実行時に動作には問題ないがログのエラーがコンソールに出るため追加しました